### PR TITLE
Add header file to objs

### DIFF
--- a/array.ipkg
+++ b/array.ipkg
@@ -4,4 +4,4 @@ modules = Data.Array
 pkgs = prelude
 
 makefile = Makefile
-objs = Array.o
+objs = Array.h, Array.o


### PR DESCRIPTION
This makes sure that header file is available for Idris C backend compilation after package has been installed.
